### PR TITLE
Bastillecode

### DIFF
--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -128,7 +128,7 @@
 			kill_count += 1
 			if(H.mind.prefs.economic_status == CLASS_UPPER)
 				for(var/mob/living/carbon/human/HM in viewers(src, 7))
-					if(HM.mind.prefs.economic_status == CLASS_LOWER)
+					if(HM.mind.prefs.economic_status == CLASS_WORKING)
 						to_chat(HM, "<span class='warning'>You watch the oppressive aristocrat bleed.</span>")				
 				
 			var/blood_overlay = "bloody"

--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -126,7 +126,11 @@
 			H.regenerate_icons()
 			unbuckle_mob()
 			kill_count += 1
-
+			if(H.mind.prefs.economic_status == CLASS_UPPER)
+				for(var/mob/living/carbon/human/HM in viewers(src, 7))
+					if(HM.mind.prefs.economic_status == CLASS_LOWER)
+						to_chat(HM, "<span class='warning'>You watch the oppressive aristocrat bleed.</span>")				
+				
 			var/blood_overlay = "bloody"
 
 			if(kill_count == 2)


### PR DESCRIPTION
Makes lower-class citizens class-conscious during beheadings.

Displays in red for obvious reasons.